### PR TITLE
Control multiple file upload from HTML

### DIFF
--- a/Classes/BrowserComponents/SEBBrowserWindow.m
+++ b/Classes/BrowserComponents/SEBBrowserWindow.m
@@ -854,7 +854,7 @@
 
 // Downloading and Uploading of Files //
 
-- (void)webView:(SEBWebView *)sender runOpenPanelForFileButtonWithResultListener:(id < WebOpenPanelResultListener >)resultListener
+- (void)webView:(SEBWebView *)sender runOpenPanelForFileButtonWithResultListener:(id < WebOpenPanelResultListener >)resultListener allowMultipleFiles:(BOOL)allowMultipleFiles;
 // Choose file for upload
 {
     NSUserDefaults *preferences = [NSUserDefaults standardUserDefaults];
@@ -912,7 +912,7 @@
         [openFilePanel setCanChooseFiles:YES];
         
         // Allow the user to open multiple files at a time.
-        openFilePanel.allowsMultipleSelection = YES;
+        openFilePanel.allowsMultipleSelection = allowMultipleFiles;
         
         // Disable the selection of directories in the dialog.
         [openFilePanel setCanChooseDirectories:NO];

--- a/Classes/BrowserComponents/SEBBrowserWindow.m
+++ b/Classes/BrowserComponents/SEBBrowserWindow.m
@@ -912,7 +912,7 @@
         [openFilePanel setCanChooseFiles:YES];
         
         // Allow the user to open multiple files at a time.
-        openFilePanel.allowsMultipleSelection = allowMultipleFiles;
+        [openFilePanel setAllowsMultipleSelection:allowMultipleFiles];
         
         // Disable the selection of directories in the dialog.
         [openFilePanel setCanChooseDirectories:NO];


### PR DESCRIPTION
This is an attempt to have the HTML input element decide if multiple files should be selectable or not (decided by the multiple-attribute), instead of always using YES.

Here's a simple test page for this, where the first file input does not specify `multiple` but where the second does. This does seem to behave correctly when I build SEB locally.
https://krisell.se/file-input-test.html

Please note that I am not a native application developer, and I have very little knowledge of Objective-C and Apple APIs. I also didn't find any tests for this, so please point me in the right direction if I missed them.