### PR TITLE
Add option to set downloaded filename in JavaScript

### DIFF
--- a/Classes/BrowserComponents/SEBBrowserWindow.m
+++ b/Classes/BrowserComponents/SEBBrowserWindow.m
@@ -1696,6 +1696,11 @@ decisionListener:(id < WebPolicyDecisionListener >)listener
         [self startDownloadingURL:request.URL];
         return;
     }
+	
+    // The filename can optionally be specified in JavaScript as window.SafeExamBrowser.download.filename = filename
+    if ([[sender stringByEvaluatingJavaScriptFromString:@"window.SafeExamBrowser.download.filename"] length] > 0) {
+        self.downloadFilename = [sender stringByEvaluatingJavaScriptFromString:@"window.SafeExamBrowser.download.filename"];
+    }
 
     NSUserDefaults *preferences = [NSUserDefaults standardUserDefaults];
 //    if (([type isEqualToString:@"application/seb"]) || ([request.URL.pathExtension isEqualToString:@"seb"])) {


### PR DESCRIPTION
Currently, file downloads initiated by JavaScript get the filename "Unknown.extension". This seem to be the case both for file-saving libraries and simple a-tags generated dynamically, and the problem seems to be that the `actionInformation` points to the document node instead of the actual link node.

This has been discussed before: https://sourceforge.net/p/seb/discussion/3704033/thread/76e6d472/

This PR is a proposal to allow the filename to be set in JavaScript instead. This is highly experimental and I understand if you don't see this as fit to merge, but I still wanted to show the idea. 

I'm not sure if you already have a JavaScript API between the browser and SEB, but this solution uses a window.SafeExamBrowser object which can be set in the following way before initiating the download:

```js
window.SafeExamBrowser = {
  download: {
    filename: 'abcde.html'
  }
}
```

If the value is not set, or the SafeExamBrowser object is missing, the return value is the empty string and ignored. I don't know however if this throws an exception in the JS runtime or is silently ignored? If this is a problem, the usual `window.SafeExamBrowser && window.SafeExamBrowser.download && window.SafeExamBrowser.download.filename` approach can be used.

Finally, I should note that the current solution is really not a big issue. Regular links with the download attribute allows for filenames to be set already.
