### PR TITLE
Prevent crash when pasting twice in some JS editors in UIWebView.

### DIFF
--- a/SEB/Classes/BrowserComponents/UIWebView+SEBWebView.h
+++ b/SEB/Classes/BrowserComponents/UIWebView+SEBWebView.h
@@ -38,4 +38,11 @@
 - (NSString*)title;
 - (NSURL*)url;
 
+/**
+ Overriden to not throw exception (which would crash SEB). This method has been
+ observed to be called when pasting twice (using Cmd-V) into a certain JavaScript
+ editor (Quill), since that editor lost focus on the first paste action.
+ */
+- (void)doesNotRecognizeSelector:(SEL)aSelector;
+
 @end

--- a/SEB/Classes/BrowserComponents/UIWebView+SEBWebView.m
+++ b/SEB/Classes/BrowserComponents/UIWebView+SEBWebView.m
@@ -53,4 +53,9 @@
 }
 
 
+- (void)doesNotRecognizeSelector:(SEL)aSelector
+{
+    DDLogDebug(@"UIWebView ignoring unrecognized selector: %s", sel_getName(aSelector));
+}
+
 @end


### PR DESCRIPTION
All crashes when UIWebView receives an unrecognized selector is prevented.