### PR TITLE
SEBMAC-491 Add Allowed SEB Versions setting

### DIFF
--- a/Base.lproj/PreferencesSecurity.xib
+++ b/Base.lproj/PreferencesSecurity.xib
@@ -38,6 +38,7 @@
                 <outlet property="screenProctoringAACCapturePolicyButton" destination="spC-Pu-001" id="spC-Ou-001"/>
                 <outlet property="screenProctoringAACCapturePolicyLabel" destination="spC-Lb-001" id="spC-Ou-002"/>
                 <outlet property="screenSharingMacEnforceButton" destination="pn0-dK-cZw" id="Dwt-bW-mjY"/>
+                <outlet property="securitySettingsStackView" destination="NFT-WK-gUf" id="Asv-01-stk"/>
                 <outlet property="selectStandardDirectoryButton" destination="eiE-cV-UEx" id="04p-z9-Sbk"/>
                 <outlet property="view" destination="1" id="4"/>
             </connections>

--- a/Classes/ConfigFiles/SEBAllowedSEBVersions.h
+++ b/Classes/ConfigFiles/SEBAllowedSEBVersions.h
@@ -1,0 +1,80 @@
+//
+//  SEBAllowedSEBVersions.h
+//  SafeExamBrowser
+//
+//  Created by Daniel R. Schneider on 14.08.26.
+//  Copyright (c) 2010-2026 Daniel R. Schneider, ETH Zurich, IT Services,
+//  based on the original idea of Safe Exam Browser
+//  by Stefan Schneider, University of Giessen
+//  Project concept: Thomas Piendl, Daniel R. Schneider, Damian Buechel,
+//  Dirk Bauer, Kai Reuter, Tobias Halbherr, Karsten Burger, Marco Lehre,
+//  Brigitte Schmucki, Oliver Rahs. French localization: Nicolas Dunand
+//
+//  ``The contents of this file are subject to the Mozilla Public License
+//  Version 2.0 (the "License"); you may not use this file except in
+//  compliance with the License. You may obtain a copy of the License at
+//  http://www.mozilla.org/MPL/
+//
+//  Software distributed under the License is distributed on an "AS IS"
+//  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+//  License for the specific language governing rights and limitations
+//  under the License.
+//
+//  The Original Code is Safe Exam Browser for Mac OS X.
+//
+//  The Initial Developer of the Original Code is Daniel R. Schneider.
+//  Portions created by Daniel R. Schneider are Copyright
+//  (c) 2010-2026 Daniel R. Schneider, ETH Zurich, IT Services,
+//  based on the original idea of Safe Exam Browser
+//  by Stefan Schneider, University of Giessen. All Rights Reserved.
+//
+//  Contributor(s): ______________________________________.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSInteger, SEBAllowedVersionPlatform) {
+    SEBAllowedVersionPlatformMac,
+    SEBAllowedVersionPlatformWin,
+    SEBAllowedVersionPlatformiOS,
+};
+
+/// Evaluates whether the running SEB build satisfies the version restrictions
+/// specified by the `sebAllowedVersions` configuration key.
+///
+/// A restriction string has the format `OS.Major.Minor.[Patch].[Build].[AE].[min]`
+/// where the bracketed components are optional:
+///  - OS: "Win", "Mac" or "iOS"
+///  - Major, Minor: required integers
+///  - Patch, Build: optional integers
+///  - AE: optional literal "AE" token marking the Alliance Edition
+///  - min: optional literal "min" token meaning "this version or newer"
+///
+/// The class is intentionally free of any AppKit / NSUserDefaults / MyGlobals
+/// dependency so that it can be unit tested in isolation: the caller passes in the
+/// running version, build number, platform and Alliance-Edition flag.
+@interface SEBAllowedSEBVersions : NSObject
+
+/// Returns YES if the running build is allowed to run with the given restrictions.
+/// An empty or nil `restrictions` array means "no restriction" and returns YES.
+/// A non-empty list that contains no satisfiable restriction for `platform` returns
+/// NO (the running platform/version is not among the allowed ones).
+- (BOOL)allowedSEBVersion:(NSString *)version
+              buildNumber:(nullable NSString *)build
+                 platform:(SEBAllowedVersionPlatform)platform
+          allianceEdition:(BOOL)allianceEdition
+       fromVersionStrings:(nullable NSArray<NSString *> *)restrictions;
+
+/// Returns a localized, human-readable description of the version requirement for
+/// the given platform, suitable for an alert's informative text (e.g. "SEB version
+/// 3.9 or higher is required for this exam."). Returns nil if `restrictions` is
+/// empty or nil. Alliance-Edition-only restrictions are omitted because this
+/// (non-AE) build can never satisfy them.
+- (nullable NSString *)requirementDescriptionForPlatform:(SEBAllowedVersionPlatform)platform
+                                      fromVersionStrings:(nullable NSArray<NSString *> *)restrictions;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Classes/ConfigFiles/SEBAllowedSEBVersions.m
+++ b/Classes/ConfigFiles/SEBAllowedSEBVersions.m
@@ -1,0 +1,309 @@
+//
+//  SEBAllowedSEBVersions.m
+//  SafeExamBrowser
+//
+//  Created by Daniel R. Schneider on 14.08.26.
+//  Copyright (c) 2010-2026 Daniel R. Schneider, ETH Zurich, IT Services,
+//  based on the original idea of Safe Exam Browser
+//  by Stefan Schneider, University of Giessen
+//  Project concept: Thomas Piendl, Daniel R. Schneider, Damian Buechel,
+//  Dirk Bauer, Kai Reuter, Tobias Halbherr, Karsten Burger, Marco Lehre,
+//  Brigitte Schmucki, Oliver Rahs. French localization: Nicolas Dunand
+//
+//  ``The contents of this file are subject to the Mozilla Public License
+//  Version 2.0 (the "License"); you may not use this file except in
+//  compliance with the License. You may obtain a copy of the License at
+//  http://www.mozilla.org/MPL/
+//
+//  Software distributed under the License is distributed on an "AS IS"
+//  basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+//  License for the specific language governing rights and limitations
+//  under the License.
+//
+//  The Original Code is Safe Exam Browser for Mac OS X.
+//
+//  The Initial Developer of the Original Code is Daniel R. Schneider.
+//  Portions created by Daniel R. Schneider are Copyright
+//  (c) 2010-2026 Daniel R. Schneider, ETH Zurich, IT Services,
+//  based on the original idea of Safe Exam Browser
+//  by Stefan Schneider, University of Giessen. All Rights Reserved.
+//
+//  Contributor(s): ______________________________________.
+//
+
+#import "SEBAllowedSEBVersions.h"
+
+#pragma mark - Helpers
+
+/// Returns YES if the string consists solely of decimal digits (and is non-empty).
+static BOOL SEBIsNonNegativeInteger(NSString *string)
+{
+    if (string.length == 0) {
+        return NO;
+    }
+    NSCharacterSet *nonDigits = [[NSCharacterSet decimalDigitCharacterSet] invertedSet];
+    return [string rangeOfCharacterFromSet:nonDigits].location == NSNotFound;
+}
+
+
+#pragma mark - Parsed restriction
+
+/// A single parsed version restriction (one entry of the sebAllowedVersions array).
+@interface SEBVersionRestriction : NSObject
+@property (nonatomic) SEBAllowedVersionPlatform platform;
+@property (nonatomic) NSInteger major;
+@property (nonatomic) NSInteger minor;
+@property (nonatomic) NSInteger patch;
+@property (nonatomic) NSInteger build;
+@property (nonatomic) BOOL allianceEdition;
+@property (nonatomic) BOOL minimum;
+/// Number of version-number components explicitly specified (2...4).
+@property (nonatomic) NSUInteger specifiedComponents;
++ (nullable instancetype)restrictionFromString:(NSString *)string;
+/// The specified version components joined with ".", e.g. "3.9" or "3.4.1".
+- (NSString *)versionString;
+@end
+
+
+@implementation SEBVersionRestriction
+
++ (nullable instancetype)restrictionFromString:(NSString *)string
+{
+    NSString *trimmed = [string stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    if (trimmed.length == 0) {
+        return nil;
+    }
+    NSArray<NSString *> *tokens = [trimmed componentsSeparatedByString:@"."];
+    // At minimum OS.Major.Minor is required.
+    if (tokens.count < 3) {
+        return nil;
+    }
+
+    SEBVersionRestriction *restriction = [SEBVersionRestriction new];
+
+    // OS token
+    NSString *osToken = tokens[0];
+    if ([osToken caseInsensitiveCompare:@"Mac"] == NSOrderedSame) {
+        restriction.platform = SEBAllowedVersionPlatformMac;
+    } else if ([osToken caseInsensitiveCompare:@"Win"] == NSOrderedSame) {
+        restriction.platform = SEBAllowedVersionPlatformWin;
+    } else if ([osToken caseInsensitiveCompare:@"iOS"] == NSOrderedSame) {
+        restriction.platform = SEBAllowedVersionPlatformiOS;
+    } else {
+        return nil;
+    }
+
+    // Major and minor (required integers)
+    if (!SEBIsNonNegativeInteger(tokens[1]) || !SEBIsNonNegativeInteger(tokens[2])) {
+        return nil;
+    }
+    restriction.major = tokens[1].integerValue;
+    restriction.minor = tokens[2].integerValue;
+
+    // Remaining optional tokens, left to right: up to two integers (patch, build),
+    // then optional "AE", then optional "min" (which must be last).
+    NSUInteger numericComponents = 0;
+    for (NSUInteger i = 3; i < tokens.count; i++) {
+        NSString *token = tokens[i];
+        if ([token caseInsensitiveCompare:@"min"] == NSOrderedSame) {
+            if (restriction.minimum || i != tokens.count - 1) {
+                return nil; // duplicate, or "min" not the last token
+            }
+            restriction.minimum = YES;
+        } else if ([token caseInsensitiveCompare:@"AE"] == NSOrderedSame) {
+            if (restriction.allianceEdition || restriction.minimum) {
+                return nil; // duplicate, or "AE" after "min"
+            }
+            restriction.allianceEdition = YES;
+        } else if (SEBIsNonNegativeInteger(token)) {
+            if (restriction.allianceEdition || restriction.minimum || numericComponents >= 2) {
+                return nil; // numeric token after AE/min, or more than patch+build
+            }
+            if (numericComponents == 0) {
+                restriction.patch = token.integerValue;
+            } else {
+                restriction.build = token.integerValue;
+            }
+            numericComponents++;
+        } else {
+            return nil; // unknown token
+        }
+    }
+
+    restriction.specifiedComponents = 2 + numericComponents;
+    return restriction;
+}
+
+- (NSString *)versionString
+{
+    NSMutableArray<NSString *> *components = [NSMutableArray arrayWithObjects:
+                                              @(self.major).stringValue,
+                                              @(self.minor).stringValue, nil];
+    if (self.specifiedComponents >= 3) {
+        [components addObject:@(self.patch).stringValue];
+    }
+    if (self.specifiedComponents >= 4) {
+        [components addObject:@(self.build).stringValue];
+    }
+    return [components componentsJoinedByString:@"."];
+}
+
+@end
+
+
+#pragma mark - SEBAllowedSEBVersions
+
+@implementation SEBAllowedSEBVersions
+
+- (BOOL)allowedSEBVersion:(NSString *)version
+              buildNumber:(nullable NSString *)build
+                 platform:(SEBAllowedVersionPlatform)platform
+          allianceEdition:(BOOL)allianceEdition
+       fromVersionStrings:(nullable NSArray<NSString *> *)restrictions
+{
+    if (restrictions.count == 0) {
+        return YES; // No restriction specified: any version is allowed.
+    }
+
+    NSArray<NSNumber *> *running = [self versionComponentsForVersion:version buildNumber:build];
+
+    NSUInteger validRestrictionCount = 0;
+    BOOL foundRelevantRestriction = NO;
+    for (NSString *restrictionString in restrictions) {
+        SEBVersionRestriction *restriction = [SEBVersionRestriction restrictionFromString:restrictionString];
+        if (!restriction) {
+            DDLogWarn(@"%s Ignoring empty or malformed sebAllowedVersions entry: %@", __FUNCTION__, restrictionString);
+            continue;
+        }
+        validRestrictionCount++;
+        if (restriction.platform != platform) {
+            continue; // Restriction is for another platform.
+        }
+        foundRelevantRestriction = YES;
+        // Alliance Edition must match exactly (this build's AE flag vs. the restriction's).
+        if (restriction.allianceEdition != allianceEdition) {
+            continue;
+        }
+        if ([self running:running satisfiesRestriction:restriction]) {
+            return YES;
+        }
+    }
+
+    if (validRestrictionCount == 0) {
+        // The list contained only empty/malformed entries: treat it as no restriction
+        // rather than blocking (e.g. an accidentally added blank row).
+        DDLogWarn(@"%s sebAllowedVersions contained only empty/malformed entries; treating as no restriction.", __FUNCTION__);
+        return YES;
+    }
+
+    if (!foundRelevantRestriction) {
+        DDLogWarn(@"%s sebAllowedVersions specifies no version for this platform; running build is not allowed.", __FUNCTION__);
+    }
+    // A restriction list with valid entries but no satisfiable one for this platform
+    // means the running build is not among the allowed versions.
+    return NO;
+}
+
+
+- (nullable NSString *)requirementDescriptionForPlatform:(SEBAllowedVersionPlatform)platform
+                                      fromVersionStrings:(nullable NSArray<NSString *> *)restrictions
+{
+    if (restrictions.count == 0) {
+        return nil;
+    }
+
+    NSMutableArray<NSString *> *minVersions = [NSMutableArray array];
+    NSMutableArray<NSString *> *exactVersions = [NSMutableArray array];
+    for (NSString *restrictionString in restrictions) {
+        SEBVersionRestriction *restriction = [SEBVersionRestriction restrictionFromString:restrictionString];
+        // Skip malformed entries, entries for other platforms and Alliance-Edition
+        // entries (this build is never AE, so they can't apply).
+        if (!restriction || restriction.platform != platform || restriction.allianceEdition) {
+            continue;
+        }
+        if (restriction.minimum) {
+            [minVersions addObject:restriction.versionString];
+        } else {
+            [exactVersions addObject:restriction.versionString];
+        }
+    }
+
+    if (minVersions.count == 0 && exactVersions.count == 0) {
+        return NSLocalizedString(@"This version of SEB is not allowed for this exam.", @"");
+    }
+
+    NSString *minClause = nil;
+    if (minVersions.count > 0) {
+        NSString *joined = [minVersions componentsJoinedByString:@", "];
+        minClause = minVersions.count == 1 ?
+            [NSString stringWithFormat:NSLocalizedString(@"SEB version %@ or higher", @""), joined] :
+            [NSString stringWithFormat:NSLocalizedString(@"one of the SEB versions %@ or higher", @""), joined];
+    }
+
+    NSString *exactClause = nil;
+    if (exactVersions.count > 0) {
+        NSString *joined = [exactVersions componentsJoinedByString:@", "];
+        exactClause = exactVersions.count == 1 ?
+            [NSString stringWithFormat:NSLocalizedString(@"SEB version %@", @""), joined] :
+            [NSString stringWithFormat:NSLocalizedString(@"one of the SEB versions %@", @""), joined];
+    }
+
+    NSString *requirement;
+    if (minClause && exactClause) {
+        requirement = [NSString stringWithFormat:NSLocalizedString(@"%@, or %@", @""), minClause, exactClause];
+    } else {
+        requirement = minClause ?: exactClause;
+    }
+    return [NSString stringWithFormat:NSLocalizedString(@"%@ is required for this exam.", @""), requirement];
+}
+
+
+#pragma mark - Private
+
+/// Maps the running version string and build number into [major, minor, patch, build].
+- (NSArray<NSNumber *> *)versionComponentsForVersion:(NSString *)version buildNumber:(nullable NSString *)build
+{
+    NSInteger major = 0, minor = 0, patch = 0;
+    NSArray<NSString *> *parts = [version componentsSeparatedByString:@"."];
+    if (parts.count > 0 && SEBIsNonNegativeInteger(parts[0])) {
+        major = parts[0].integerValue;
+    }
+    if (parts.count > 1 && SEBIsNonNegativeInteger(parts[1])) {
+        minor = parts[1].integerValue;
+    }
+    if (parts.count > 2 && SEBIsNonNegativeInteger(parts[2])) {
+        patch = parts[2].integerValue;
+    }
+    // CFBundleVersion is treated as a single integer; -integerValue tolerates a nil
+    // or non-numeric build (returns 0 / the leading integer).
+    NSInteger buildNumber = build.integerValue;
+    return @[@(major), @(minor), @(patch), @(buildNumber)];
+}
+
+
+/// Compares the running version against a restriction, considering only the
+/// components the restriction explicitly specified.
+- (BOOL)running:(NSArray<NSNumber *> *)running satisfiesRestriction:(SEBVersionRestriction *)restriction
+{
+    NSArray<NSNumber *> *required = @[@(restriction.major), @(restriction.minor),
+                                      @(restriction.patch), @(restriction.build)];
+    for (NSUInteger i = 0; i < restriction.specifiedComponents; i++) {
+        NSInteger runningValue = running[i].integerValue;
+        NSInteger requiredValue = required[i].integerValue;
+        if (restriction.minimum) {
+            if (runningValue > requiredValue) {
+                return YES; // A newer component means the minimum is satisfied.
+            }
+            if (runningValue < requiredValue) {
+                return NO;  // An older component means it is not.
+            }
+            // Equal component: continue comparing the next one.
+        } else if (runningValue != requiredValue) {
+            return NO; // Exact match required.
+        }
+    }
+    // All specified components matched (exact) or were equal up to here (minimum).
+    return YES;
+}
+
+@end

--- a/Classes/ConfigFiles/SEBAllowedSEBVersionsTestSupport.swift
+++ b/Classes/ConfigFiles/SEBAllowedSEBVersionsTestSupport.swift
@@ -1,0 +1,40 @@
+//
+//  SEBAllowedSEBVersionsTestSupport.swift
+//  SafeExamBrowser
+//
+//  Test-only bridge that exposes the Objective-C SEBAllowedSEBVersions class to
+//  the Swift unit test target. The test target links the app module but cannot see
+//  Objective-C classes directly, so this small @objc public wrapper (part of the
+//  app's Swift module) provides access.
+//  Compiled only in DEBUG builds — nothing ships in release.
+//
+
+#if DEBUG
+import Foundation
+
+@objc public final class SEBAllowedSEBVersionsTestSupport: NSObject {
+
+    /// Wraps -[SEBAllowedSEBVersions allowedSEBVersion:buildNumber:platform:allianceEdition:fromVersionStrings:].
+    /// `platform` uses the SEBAllowedVersionPlatform raw values (Mac = 0, Win = 1, iOS = 2).
+    @objc public static func allowed(version: String,
+                                     buildNumber: String?,
+                                     platform: Int,
+                                     allianceEdition: Bool,
+                                     restrictions: [String]?) -> Bool {
+        let checker = SEBAllowedSEBVersions()
+        return checker.allowedSEBVersion(version,
+                                         buildNumber: buildNumber,
+                                         platform: SEBAllowedVersionPlatform(rawValue: platform)!,
+                                         allianceEdition: allianceEdition,
+                                         fromVersionStrings: restrictions)
+    }
+
+    /// Wraps -[SEBAllowedSEBVersions requirementDescriptionForPlatform:fromVersionStrings:].
+    @objc public static func requirementDescription(platform: Int,
+                                                     restrictions: [String]?) -> String? {
+        let checker = SEBAllowedSEBVersions()
+        return checker.requirementDescription(for: SEBAllowedVersionPlatform(rawValue: platform)!,
+                                              fromVersionStrings: restrictions)
+    }
+}
+#endif

--- a/Classes/ConfigFiles/SEBSettings.m
+++ b/Classes/ConfigFiles/SEBSettings.m
@@ -928,7 +928,10 @@ static SEBSettings *sharedSEBSettings = nil;
                    
                    @NO,
                    @"screenSharingMacEnforceBlocked",
-                   
+
+                   [NSArray array],
+                   @"sebAllowedVersions",
+
                    [NSNumber numberWithLong:sebConfigPurposeDefault],
                    @"sebConfigPurpose",
                    

--- a/Classes/Global/SEBConstants.h
+++ b/Classes/Global/SEBConstants.h
@@ -46,6 +46,8 @@ static NSString __unused *sebErrorDomain = @"org.safeexambrowser.SEB";
 
 static NSString __unused *SEBStartPage = @"https://safeexambrowser.org/start";
 static NSString __unused *SEBHelpPage = @"https://safeexambrowser.org/macosx";
+// Localized download page: the "%@" is replaced by a language code (e.g. "en", "de", "fr").
+static NSString __unused *SEBDownloadPageFormat = @"https://safeexambrowser.org/download_%@#MacOSX.html";
 static NSString __unused *SEBSupportEmail = @"info@safeexambrowser.org";
 static NSString __unused *SEBWebsiteShort = @"safeexambrowser.org";
 

--- a/Classes/Preferences/PreferencesWindow/PreferencesController.m
+++ b/Classes/Preferences/PreferencesWindow/PreferencesController.m
@@ -303,14 +303,22 @@
 - (void)windowWillClose:(NSNotification *)notification
 {
     [self.configFileVC hideQRConfig];
-    if (self.preferencesAreOpen && !self.refreshingPreferences) {
+    // Don't post anything during the internal release/reopen "refresh" dance used to
+    // re-sync bindings (refreshingPreferences == YES).
+    if (!self.refreshingPreferences) {
 //        self.sebController.browserController.reinforceKioskModeRequested = YES;
-        // Post a notification that the preferences window closes
         if (restartSEB) {
+            // A settings change requiring a restart was applied: always post this,
+            // even if the window is no longer visible. During the reconfigure
+            // open/close dance the final close carrying restartSEB can arrive after
+            // the window was already hidden; gating it on -preferencesAreOpen
+            // (window.isVisible) would drop the notification and the session would
+            // never restart with the new settings.
             restartSEB = NO;
             [[NSNotificationCenter defaultCenter]
              postNotificationName:@"preferencesClosedRestartSEB" object:self];
-        } else {
+        } else if (self.preferencesAreOpen) {
+            // Post a notification that the preferences window closes (no reconfiguration)
             [[NSNotificationCenter defaultCenter]
              postNotificationName:@"preferencesClosed" object:self];
         }

--- a/Classes/Preferences/PreferencesWindow/PreferencesViewControllers/PrefsSecurityViewController.h
+++ b/Classes/Preferences/PreferencesWindow/PreferencesViewControllers/PrefsSecurityViewController.h
@@ -72,6 +72,10 @@
     __weak IBOutlet NSComboBox *allowediOSBetaVersion;
     
     __weak IBOutlet NSButton *enablePrintScreenButton;
+
+    // Main vertical stack view of the Security pane. The "Allowed SEB Versions"
+    // section is built programmatically and appended here (see the .m).
+    __weak IBOutlet NSStackView *securitySettingsStackView;
 }
 
 - (NSString *)identifier;

--- a/Classes/Preferences/PreferencesWindow/PreferencesViewControllers/PrefsSecurityViewController.m
+++ b/Classes/Preferences/PreferencesWindow/PreferencesViewControllers/PrefsSecurityViewController.m
@@ -35,6 +35,17 @@
 
 #import "PrefsSecurityViewController.h"
 
+static NSString * const allowedSEBVersionsKey = @"org_safeexambrowser_SEB_sebAllowedVersions";
+
+@interface PrefsSecurityViewController () <NSTableViewDataSource, NSTableViewDelegate>
+{
+    // Programmatically created "Allowed SEB Versions" controls.
+    NSTableView *allowedSEBVersionsTableView;
+    NSMutableArray<NSString *> *allowedSEBVersions;
+    BOOL allowedSEBVersionsSectionBuilt;
+}
+@end
+
 @implementation PrefsSecurityViewController
 
 - (NSString *)title
@@ -66,6 +77,8 @@
     [miniOSVersionMinor addItemsWithObjectValues:@[@0, @1, @2, @3, @4, @5, @6, @7, @8, @9]];
     [miniOSVersionPatch addItemsWithObjectValues:@[@0, @1, @2, @3, @4, @5, @6, @7, @8, @9]];
     [allowediOSBetaVersion addItemsWithObjectValues:@[@0, [NSNumber numberWithInt:iOSBetaVersion26]]];
+
+    [self buildAllowedSEBVersionsSectionIfNeeded];
 }
 
 
@@ -74,6 +87,7 @@
 {
     [self setLogDirectory];
     [self setEnableEnableAAC:self];
+    [self loadAllowedSEBVersions];
     
     NSUserDefaults *preferences = [NSUserDefaults standardUserDefaults];
     
@@ -285,6 +299,221 @@
 
 - (IBAction)setEnablePrintScreen:(NSButton *)sender {
     allowiOSScreenCaptureButton.state = sender.state;
+}
+
+
+#pragma mark - Allowed SEB Versions
+
+// Builds the "Allowed SEB Versions" section (title, description, editable table
+// and add/remove buttons) and appends it to the Security pane's main stack view.
+// The section is built once; guard against awakeFromNib being called repeatedly.
+- (void)buildAllowedSEBVersionsSectionIfNeeded
+{
+    if (allowedSEBVersionsSectionBuilt || securitySettingsStackView == nil) {
+        return;
+    }
+    allowedSEBVersionsSectionBuilt = YES;
+
+    NSTextField *titleLabel = [NSTextField labelWithString:NSLocalizedString(@"Allowed SEB Versions", @"")];
+    titleLabel.font = [NSFont boldSystemFontOfSize:[NSFont systemFontSize]];
+
+    NSTextField *descriptionLabel = [NSTextField wrappingLabelWithString:NSLocalizedString(@"Specify one or more SEB version(s) required to use this configuration, one per row. Format: OS.Major.Minor.[Patch].[Build].[AE].[min] (OS is Win, Mac or iOS; optional parts in brackets). Example: \"Win.3.9.min\" allows SEB for Windows 3.9 or newer.", @"")];
+    descriptionLabel.font = [NSFont systemFontOfSize:[NSFont smallSystemFontSize]];
+    descriptionLabel.textColor = [NSColor secondaryLabelColor];
+    descriptionLabel.selectable = NO;
+    descriptionLabel.preferredMaxLayoutWidth = 460;
+
+    // Cell-based, single-column, editable table view.
+    allowedSEBVersionsTableView = [[NSTableView alloc] initWithFrame:NSZeroRect];
+    NSTableColumn *column = [[NSTableColumn alloc] initWithIdentifier:@"version"];
+    column.editable = YES;
+    column.title = NSLocalizedString(@"SEB Version", @"");
+    [allowedSEBVersionsTableView addTableColumn:column];
+    allowedSEBVersionsTableView.headerView = nil;
+    allowedSEBVersionsTableView.usesAlternatingRowBackgroundColors = YES;
+    allowedSEBVersionsTableView.columnAutoresizingStyle = NSTableViewUniformColumnAutoresizingStyle;
+    allowedSEBVersionsTableView.allowsMultipleSelection = YES;
+    allowedSEBVersionsTableView.rowHeight = 19;
+    allowedSEBVersionsTableView.dataSource = self;
+    allowedSEBVersionsTableView.delegate = self;
+
+    NSScrollView *scrollView = [[NSScrollView alloc] initWithFrame:NSZeroRect];
+    scrollView.documentView = allowedSEBVersionsTableView;
+    scrollView.hasVerticalScroller = YES;
+    scrollView.borderType = NSBezelBorder;
+    scrollView.translatesAutoresizingMaskIntoConstraints = NO;
+    // Nudge the content down slightly so the first row isn't drawn flush against the top
+    // bezel (otherwise it looks shifted up by ~2 pt).
+    scrollView.automaticallyAdjustsContentInsets = NO;
+    scrollView.contentInsets = NSEdgeInsetsMake(2, 0, 0, 0);
+    // Size the visible area to a whole number of rows so the bottom row is never cropped
+    // with default macOS 26 metrics. Derived from the actual row height + intercell spacing
+    // (plus the content insets) so it stays correct if those change.
+    NSInteger visibleRows = 3;
+    CGFloat rowUnit = allowedSEBVersionsTableView.rowHeight + allowedSEBVersionsTableView.intercellSpacing.height;
+    NSSize contentSize = NSMakeSize(460, rowUnit * visibleRows + scrollView.contentInsets.top + scrollView.contentInsets.bottom);
+    NSSize frameSize = [NSScrollView frameSizeForContentSize:contentSize
+                                     horizontalScrollerClass:Nil
+                                       verticalScrollerClass:Nil
+                                                  borderType:scrollView.borderType
+                                                 controlSize:NSControlSizeRegular
+                                               scrollerStyle:NSScrollerStyleOverlay];
+    [scrollView.heightAnchor constraintEqualToConstant:frameSize.height].active = YES;
+    [scrollView.widthAnchor constraintEqualToConstant:460].active = YES;
+
+    NSSegmentedControl *addRemoveControl = [NSSegmentedControl segmentedControlWithLabels:@[@"+", @"−"]
+                                                                             trackingMode:NSSegmentSwitchTrackingMomentary
+                                                                                   target:self
+                                                                                   action:@selector(addRemoveAllowedSEBVersion:)];
+    addRemoveControl.segmentStyle = NSSegmentStyleSmallSquare;
+    // Make both segments square (segment width == control height).
+    [addRemoveControl sizeToFit];
+    CGFloat segmentSide = addRemoveControl.fittingSize.height;
+    [addRemoveControl setWidth:segmentSide forSegment:0];
+    [addRemoveControl setWidth:segmentSide forSegment:1];
+
+    NSStackView *section = [[NSStackView alloc] initWithFrame:NSZeroRect];
+    section.orientation = NSUserInterfaceLayoutOrientationVertical;
+    section.alignment = NSLayoutAttributeLeading;
+    section.spacing = 6;
+    section.translatesAutoresizingMaskIntoConstraints = NO;
+    [section addArrangedSubview:titleLabel];
+    [section addArrangedSubview:descriptionLabel];
+    [section addArrangedSubview:scrollView];
+    [section addArrangedSubview:addRemoveControl];
+
+    [securitySettingsStackView addArrangedSubview:section];
+}
+
+
+// Handles the momentary add (segment 0) / remove (segment 1) segmented control.
+- (void)addRemoveAllowedSEBVersion:(NSSegmentedControl *)sender
+{
+    if (sender.selectedSegment == 0) {
+        [self addAllowedSEBVersion:sender];
+    } else {
+        [self removeAllowedSEBVersion:sender];
+    }
+}
+
+
+- (void)addAllowedSEBVersion:(id)sender
+{
+    if (allowedSEBVersions == nil) {
+        allowedSEBVersions = [NSMutableArray array];
+    }
+    [allowedSEBVersions addObject:@""];
+    [allowedSEBVersionsTableView reloadData];
+    [self saveAllowedSEBVersions];
+    NSInteger row = allowedSEBVersions.count - 1;
+    [allowedSEBVersionsTableView editColumn:0 row:row withEvent:nil select:YES];
+}
+
+
+- (void)removeAllowedSEBVersion:(id)sender
+{
+    NSIndexSet *selectedRows = allowedSEBVersionsTableView.selectedRowIndexes;
+    if (selectedRows.count == 0) {
+        return;
+    }
+    // Discard any in-progress cell editing first: otherwise ending the edit while
+    // removing commits/queries a row index that no longer exists once the model
+    // shrinks (which would crash with an out-of-bounds array access).
+    [allowedSEBVersionsTableView abortEditing];
+    [allowedSEBVersionsTableView.window makeFirstResponder:allowedSEBVersionsTableView];
+    // Only remove indexes that are actually within bounds of the model.
+    NSMutableIndexSet *rowsToRemove = [selectedRows mutableCopy];
+    [rowsToRemove removeIndexesInRange:NSMakeRange(allowedSEBVersions.count, NSUIntegerMax - allowedSEBVersions.count)];
+    if (rowsToRemove.count == 0) {
+        return;
+    }
+    [allowedSEBVersions removeObjectsAtIndexes:rowsToRemove];
+    [allowedSEBVersionsTableView reloadData];
+    [self saveAllowedSEBVersions];
+}
+
+
+- (void)loadAllowedSEBVersions
+{
+    NSUserDefaults *preferences = [NSUserDefaults standardUserDefaults];
+    NSArray<NSString *> *storedVersions = [preferences secureStringArrayForKey:allowedSEBVersionsKey];
+    allowedSEBVersions = storedVersions ? [storedVersions mutableCopy] : [NSMutableArray array];
+    [allowedSEBVersionsTableView reloadData];
+}
+
+
+- (void)saveAllowedSEBVersions
+{
+    // Persist only non-empty, trimmed entries so an accidentally added blank row (or
+    // a row left empty) is never stored into the settings array.
+    NSMutableArray<NSString *> *versionsToStore = [NSMutableArray arrayWithCapacity:allowedSEBVersions.count];
+    for (NSString *version in allowedSEBVersions) {
+        NSString *trimmed = [version stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+        if (trimmed.length > 0) {
+            [versionsToStore addObject:trimmed];
+        }
+    }
+    NSUserDefaults *preferences = [NSUserDefaults standardUserDefaults];
+    [preferences setSecureObject:[versionsToStore copy] forKey:allowedSEBVersionsKey];
+}
+
+
+#pragma mark - NSTableViewDataSource
+
+- (NSInteger)numberOfRowsInTableView:(NSTableView *)tableView
+{
+    return allowedSEBVersions.count;
+}
+
+
+- (id)tableView:(NSTableView *)tableView objectValueForTableColumn:(NSTableColumn *)tableColumn row:(NSInteger)row
+{
+    // Guard against a stale field-editor callback referencing a removed row.
+    if (row < 0 || row >= (NSInteger)allowedSEBVersions.count) {
+        return @"";
+    }
+    return allowedSEBVersions[row];
+}
+
+
+- (void)tableView:(NSTableView *)tableView setObjectValue:(id)object forTableColumn:(NSTableColumn *)tableColumn row:(NSInteger)row
+{
+    if (row < 0 || row >= (NSInteger)allowedSEBVersions.count) {
+        return;
+    }
+    NSString *value = [object isKindOfClass:[NSString class]] ? (NSString *)object : [object description];
+    value = [value stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    allowedSEBVersions[row] = value ?: @"";
+    [self saveAllowedSEBVersions];
+    // Empty rows are removed once editing ends (see controlTextDidEndEditing:).
+}
+
+
+// Removes any empty (or whitespace-only) entries from the model and table. Called after
+// editing ends so a blank row never lingers — whether the edit was confirmed empty with
+// Enter, cancelled with Escape, or ended by clicking away / closing the window. Deferred
+// to the next run loop so the table isn't mutated from within the field editor callback.
+- (void)removeEmptyAllowedSEBVersionRows
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSIndexSet *emptyRows = [self->allowedSEBVersions indexesOfObjectsPassingTest:^BOOL(NSString *version, NSUInteger idx, BOOL *stop) {
+            return [version stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]].length == 0;
+        }];
+        if (emptyRows.count == 0) {
+            return;
+        }
+        [self->allowedSEBVersions removeObjectsAtIndexes:emptyRows];
+        [self->allowedSEBVersionsTableView reloadData];
+        [self saveAllowedSEBVersions];
+    });
+}
+
+
+#pragma mark - NSTableViewDelegate
+
+- (void)controlTextDidEndEditing:(NSNotification *)notification
+{
+    [self removeEmptyAllowedSEBVersionRows];
 }
 
 

--- a/Classes/SEBController.m
+++ b/Classes/SEBController.m
@@ -82,6 +82,7 @@
 #import "NSScreen+SEBScreen.h"
 #import "NSWindow+SEBWindow.h"
 #import "SEBConfigFileManager.h"
+#import "SEBAllowedSEBVersions.h"
 #import "NSRunningApplication+SEB.h"
 #import "ProcessManager.h"
 
@@ -2791,7 +2792,7 @@ static NSString * const kSEBWiFiKeychainService = @"org.safeexambrowser.SEB.wifi
         return;
     }
     DDLogDebug(@"%s", __FUNCTION__);
-    
+
     /// Kiosk mode checks
     
     // Update AAC availability before version check
@@ -2799,6 +2800,13 @@ static NSString * const kSEBWiFiKeychainService = @"org.safeexambrowser.SEB.wifi
 
     // Check if running on minimal macOS version
     [self checkMinMacOSVersion];
+
+    // Check if the running SEB version is allowed by the current settings. If not,
+    // abort initialization here: the alert is presented (deferred) and SEB quits,
+    // so the session must not continue to start (no browser window etc.).
+    if (![self checkAllowedSEBVersions]) {
+        return;
+    }
 
     // Check if AAC Assessment Mode is enforced but unsupported on this macOS version
     if (enforceAACUnsupportedMacOS) {
@@ -5576,6 +5584,95 @@ extern int csops(pid_t pid, unsigned int ops, void *useraddr, size_t usersize);
         [self runModalAlert:modalAlert conditionallyForWindow:self.browserController.mainBrowserWindow completionHandler:(void (^)(NSModalResponse answer))terminateSEBAlertOK];
     } else {
         DDLogInfo(@"%s: Running on current macOS version is allowed.", __FUNCTION__);
+    }
+}
+
+
+// Check if the running SEB version is allowed by the current settings
+// (sebAllowedVersions). Returns YES if allowed (SEB may continue starting the
+// session), NO if not (the caller must abort initialization). When not allowed a
+// blocking alert offering to download a required SEB version is presented and SEB
+// is quit; the alert is deferred to the next run loop cycle so that an in-progress
+// preferences-close / session reconfiguration has fully settled (otherwise the
+// modal alert can fail to come to front and only appear on a later attempt).
+- (BOOL)checkAllowedSEBVersions
+{
+    NSUserDefaults *preferences = [NSUserDefaults standardUserDefaults];
+    NSArray<NSString *> *allowedVersions = [preferences secureStringArrayForKey:@"org_safeexambrowser_SEB_sebAllowedVersions"];
+
+    if (allowedVersions.count == 0) {
+        return YES; // No SEB version restriction specified.
+    }
+
+    NSString *version = [MyGlobals versionString];
+    NSString *build = [MyGlobals buildNumber];
+
+    SEBAllowedSEBVersions *allowedSEBVersions = [SEBAllowedSEBVersions new];
+    BOOL allowed = [allowedSEBVersions allowedSEBVersion:version
+                                             buildNumber:build
+                                                platform:SEBAllowedVersionPlatformMac
+                                         allianceEdition:NO
+                                      fromVersionStrings:allowedVersions];
+    if (allowed) {
+        DDLogInfo(@"%s: The running SEB version (%@ build %@) is allowed by current settings.", __FUNCTION__, version, build);
+        return YES;
+    }
+
+    NSString *requirement = [allowedSEBVersions requirementDescriptionForPlatform:SEBAllowedVersionPlatformMac
+                                                              fromVersionStrings:allowedVersions];
+    NSString *runningInfo = [NSString stringWithFormat:NSLocalizedString(@"You are running %@ version %@ (build %@). Please download and install a required version.", @""),
+                             SEBShortAppName, version, build];
+    NSString *informativeText = [NSString stringWithFormat:@"%@\n\n%@", requirement, runningInfo];
+    DDLogError(@"%s The running SEB version (%@ build %@) is not allowed. %@", __FUNCTION__, version, build, requirement);
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self presentAllowedSEBVersionsNotAllowedAlertWithInformativeText:informativeText];
+    });
+    return NO;
+}
+
+
+// Presents the "SEB Version Not Allowed!" alert and quits SEB on either button.
+- (void)presentAllowedSEBVersionsNotAllowedAlertWithInformativeText:(NSString *)informativeText
+{
+    // Bring SEB to the front so the critical alert reliably becomes key and visible
+    // (see also -presentPreferencesCorruptedError).
+    [[NSRunningApplication currentApplication] activateWithOptions:(NSApplicationActivateAllWindows | NSApplicationActivateIgnoringOtherApps)];
+
+    NSAlert *modalAlert = [self newAlert];
+    [modalAlert setMessageText:NSLocalizedString(@"SEB Version Not Allowed!", @"")];
+    [modalAlert setInformativeText:informativeText];
+    [modalAlert addButtonWithTitle:[NSString stringWithFormat:NSLocalizedString(@"Download %@", @""), SEBShortAppName]];
+    [modalAlert addButtonWithTitle:[NSString stringWithFormat:NSLocalizedString(@"Quit %@", @""), SEBShortAppName]];
+    [modalAlert setAlertStyle:NSAlertStyleCritical];
+    void (^allowedSEBVersionsAlertHandler)(NSModalResponse) = ^void (NSModalResponse answer) {
+        [self removeAlertWindow:modalAlert.window];
+        if (answer == NSAlertFirstButtonReturn) {
+            // Open the SEB download page in the default browser before quitting.
+            [self openSEBDownloadPage];
+        }
+        // A disallowed version can never continue into the exam: quit SEB entirely
+        // (both buttons), as required.
+        [self requestedExit:nil];
+    };
+    [self runModalAlert:modalAlert conditionallyForWindow:self.browserController.mainBrowserWindow completionHandler:(void (^)(NSModalResponse answer))allowedSEBVersionsAlertHandler];
+}
+
+
+// Open the localized SEB download page on the SEB website in the default browser.
+- (void)openSEBDownloadPage
+{
+    NSString *language = [NSLocale preferredLanguages].firstObject;
+    NSString *languageCode = (language.length >= 2) ? [[language substringToIndex:2] lowercaseString] : @"en";
+    // The website provides English, German and French download pages.
+    if (![@[@"en", @"de", @"fr"] containsObject:languageCode]) {
+        languageCode = @"en";
+    }
+    NSString *urlString = [NSString stringWithFormat:SEBDownloadPageFormat, languageCode];
+    NSURL *url = [NSURL URLWithString:urlString];
+    DDLogInfo(@"%s Opening SEB download page %@", __FUNCTION__, urlString);
+    if (url) {
+        [[NSWorkspace sharedWorkspace] openURL:url];
     }
 }
 

--- a/OtherSources/SEB-Bridging-Header.h
+++ b/OtherSources/SEB-Bridging-Header.h
@@ -25,4 +25,7 @@
 // Exposes the server-trust authorization decision to the (DEBUG-only) trust
 // test-support shim; see SEBBrowserControllerTrustTestSupport.swift.
 #import "SEBBrowserController+Testing.h"
+// Exposes the SEB version restriction check to the (DEBUG-only) test-support
+// shim; see SEBAllowedSEBVersionsTestSupport.swift.
+#import "SEBAllowedSEBVersions.h"
 #endif

--- a/SEBTests/SEBAllowedSEBVersionsTests.swift
+++ b/SEBTests/SEBAllowedSEBVersionsTests.swift
@@ -1,0 +1,153 @@
+//
+//  SEBAllowedSEBVersionsTests.swift
+//  SafeExamBrowserTests
+//
+//  Verifies the parsing and allow/deny decision of SEBAllowedSEBVersions, which
+//  backs the sebAllowedVersions configuration key. The class is pure (no user
+//  defaults / AppKit), so tests drive it directly through the DEBUG-only
+//  SEBAllowedSEBVersionsTestSupport shim.
+//
+//  Uses XCTest to match the other unit tests in this target.
+//
+
+import XCTest
+import Safe_Exam_Browser
+
+final class SEBAllowedSEBVersionsTests: XCTestCase {
+
+    // SEBAllowedVersionPlatform raw values
+    private let mac = 0
+    private let win = 1
+    private let ios = 2
+
+    private func allowed(_ version: String,
+                         build: String? = nil,
+                         platform: Int = 0,
+                         ae: Bool = false,
+                         _ restrictions: [String]?) -> Bool {
+        SEBAllowedSEBVersionsTestSupport.allowed(version: version,
+                                                 buildNumber: build,
+                                                 platform: platform,
+                                                 allianceEdition: ae,
+                                                 restrictions: restrictions)
+    }
+
+    // MARK: - No restriction
+
+    func testEmptyRestrictions_allowed() {
+        XCTAssertTrue(allowed("3.4.0", []))
+        XCTAssertTrue(allowed("3.4.0", nil))
+    }
+
+    // MARK: - Wrong platform only
+
+    func testOnlyOtherPlatforms_blocked() {
+        XCTAssertFalse(allowed("3.4.0", ["Win.3.9.min", "iOS.3.6"]))
+    }
+
+    // MARK: - Exact match
+
+    func testExactMatch_specifiedComponentsOnly() {
+        XCTAssertTrue(allowed("3.4.0", ["Mac.3.4"]))
+        XCTAssertTrue(allowed("3.4.1", ["Mac.3.4"]))   // extra running patch is fine for a 2-component exact rule
+        XCTAssertFalse(allowed("3.5.0", ["Mac.3.4"]))
+    }
+
+    func testExactMatch_withPatch() {
+        XCTAssertTrue(allowed("3.4.1", ["Mac.3.4.1"]))
+        XCTAssertFalse(allowed("3.4.0", ["Mac.3.4.1"]))
+    }
+
+    // MARK: - Minimum
+
+    func testMinimum_majorMinor() {
+        XCTAssertTrue(allowed("3.9.0", ["Mac.3.9.min"]))
+        XCTAssertTrue(allowed("4.0.0", ["Mac.3.9.min"]))
+        XCTAssertFalse(allowed("3.8.9", ["Mac.3.9.min"]))
+    }
+
+    func testMinimum_withPatch() {
+        XCTAssertTrue(allowed("3.4.1", ["Mac.3.4.1.min"]))
+        XCTAssertFalse(allowed("3.4.0", ["Mac.3.4.1.min"]))
+        XCTAssertTrue(allowed("3.5.0", ["Mac.3.4.1.min"]))
+    }
+
+    func testMinimum_withBuild() {
+        XCTAssertTrue(allowed("3.4.1", build: "1234", ["Mac.3.4.1.1234.min"]))
+        XCTAssertTrue(allowed("3.4.1", build: "2000", ["Mac.3.4.1.1234.min"]))
+        XCTAssertFalse(allowed("3.4.1", build: "1000", ["Mac.3.4.1.1234.min"]))
+    }
+
+    // MARK: - Alliance Edition (this Mac build is never AE)
+
+    func testAllianceEditionEntry_neverSatisfiedByNonAEBuild() {
+        XCTAssertFalse(allowed("3.9.0", ae: false, ["Mac.3.9.AE.min"]))
+    }
+
+    func testAllianceEditionEntry_siblingNonAEEntryStillAllows() {
+        XCTAssertTrue(allowed("3.9.0", ae: false, ["Mac.3.9.AE.min", "Mac.3.4.min"]))
+    }
+
+    func testAllianceEditionBuild_matchesAEEntry() {
+        XCTAssertTrue(allowed("3.9.0", ae: true, ["Mac.3.9.AE.min"]))
+    }
+
+    // MARK: - Mixed lists
+
+    func testMixedList() {
+        let list = ["Mac.3.4", "Mac.3.9.min", "Win.3.9.min"]
+        XCTAssertTrue(allowed("3.9.0", list))   // satisfies min
+        XCTAssertTrue(allowed("3.4.0", list))   // satisfies exact
+        XCTAssertFalse(allowed("3.6.0", list))  // neither
+    }
+
+    // MARK: - Malformed entries
+
+    func testOnlyEmptyOrMalformedEntries_allowed() {
+        // A list of only empty/garbage entries (e.g. an accidental blank row) is
+        // treated as "no restriction" rather than blocking.
+        XCTAssertTrue(allowed("3.4.0", ["", "Mac", "Mac.x.y", "Mac.3", "Mac.3.4.min.extra"]))
+        XCTAssertTrue(allowed("3.4.0", [""]))
+        XCTAssertTrue(allowed("3.4.0", ["   "]))
+    }
+
+    func testMalformedEntriesMixedWithValidOtherPlatform_blocked() {
+        // Garbage is skipped, but a valid non-Mac restriction still blocks the Mac build.
+        XCTAssertFalse(allowed("3.4.0", ["", "garbage", "Win.3.9.min"]))
+    }
+
+    func testMalformedEntriesSkipped_validEntryStillParsed() {
+        XCTAssertTrue(allowed("3.4.0", ["garbage", "Mac.3.4", "Foo.1.2"]))
+    }
+
+    func testWhitespaceTrimmed() {
+        XCTAssertTrue(allowed("3.9.0", ["  Mac.3.9.min  "]))
+    }
+
+    // MARK: - Requirement description
+
+    func testRequirementDescription_nilForEmpty() {
+        XCTAssertNil(SEBAllowedSEBVersionsTestSupport.requirementDescription(platform: mac, restrictions: []))
+    }
+
+    func testRequirementDescription_min() {
+        let text = SEBAllowedSEBVersionsTestSupport.requirementDescription(platform: mac, restrictions: ["Mac.3.9.min"])
+        XCTAssertNotNil(text)
+        XCTAssertTrue(text!.contains("3.9"))
+        XCTAssertTrue(text!.lowercased().contains("higher"))
+    }
+
+    func testRequirementDescription_exact() {
+        let text = SEBAllowedSEBVersionsTestSupport.requirementDescription(platform: mac, restrictions: ["Mac.3.4", "Mac.3.5.1"])
+        XCTAssertNotNil(text)
+        XCTAssertTrue(text!.contains("3.4"))
+        XCTAssertTrue(text!.contains("3.5.1"))
+    }
+
+    func testRequirementDescription_mixed() {
+        let text = SEBAllowedSEBVersionsTestSupport.requirementDescription(platform: mac, restrictions: ["Mac.3.9.min", "Mac.3.4"])
+        XCTAssertNotNil(text)
+        XCTAssertTrue(text!.contains("3.9"))
+        XCTAssertTrue(text!.contains("3.4"))
+    }
+}

--- a/SafeExamBrowser.xcodeproj/project.pbxproj
+++ b/SafeExamBrowser.xcodeproj/project.pbxproj
@@ -64,15 +64,9 @@
 		6917744A1A2776FB0039CC39 /* SEBURLFilterRegexExpression.h in Headers */ = {isa = PBXBuildFile; fileRef = 691774481A2776FB0039CC39 /* SEBURLFilterRegexExpression.h */; };
 		6917744B1A2776FB0039CC39 /* SEBURLFilterRegexExpression.m in Sources */ = {isa = PBXBuildFile; fileRef = 691774491A2776FB0039CC39 /* SEBURLFilterRegexExpression.m */; };
 		6918BCB5301ACEEC00E602A2 /* SEBLockdownModePolicyMigrationTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6918BCB4301ACEEC00E602A2 /* SEBLockdownModePolicyMigrationTestSupport.swift */; };
-		FEED0000000000000000A002 /* SEBBrowserControllerTrustTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000A001 /* SEBBrowserControllerTrustTestSupport.swift */; };
-		FEED0000000000000000A004 /* SEBBrowserControllerTrustTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000A003 /* SEBBrowserControllerTrustTests.swift */; };
 		6918BCB7301ACF9E00E602A2 /* SEBLockdownModePolicyMigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6918BCB6301ACF9E00E602A2 /* SEBLockdownModePolicyMigrationTests.swift */; };
 		6918BCB92D419BA5002A9C57 /* SEBGCMCryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6918BCB82D419BA5002A9C57 /* SEBGCMCryptor.swift */; };
 		6918BCBA2D419BA5002A9C57 /* SEBGCMCryptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6918BCB82D419BA5002A9C57 /* SEBGCMCryptor.swift */; };
-		FEED0000000000000000C012 /* SEBServerCertificateFetchUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000C011 /* SEBServerCertificateFetchUI.swift */; };
-		FEED0000000000000000C013 /* SEBServerCertificateFetchUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000C011 /* SEBServerCertificateFetchUI.swift */; };
-		FEED0000000000000000C002 /* SEBServerCertificateFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000C001 /* SEBServerCertificateFetcher.swift */; };
-		FEED0000000000000000C003 /* SEBServerCertificateFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000C001 /* SEBServerCertificateFetcher.swift */; };
 		691981422C723B7500E79DA4 /* FIFOBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 691981412C723B7500E79DA4 /* FIFOBuffer.swift */; };
 		691981432C723B7500E79DA4 /* FIFOBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 691981412C723B7500E79DA4 /* FIFOBuffer.swift */; };
 		691981452C72520A00E79DA4 /* ScreenShotCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 691981442C72520A00E79DA4 /* ScreenShotCache.swift */; };
@@ -87,9 +81,7 @@
 		691CC4131BA134070020D3EC /* RNEncryptor.m in Sources */ = {isa = PBXBuildFile; fileRef = 69DFAF2819C468E700CBE69F /* RNEncryptor.m */; };
 		691CC4141BA134070020D3EC /* RNCryptorEngine.m in Sources */ = {isa = PBXBuildFile; fileRef = 69DFAF2A19C468E700CBE69F /* RNCryptorEngine.m */; };
 		6921294216F91C6600AFC3B0 /* BoolValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 6921294016F91C6600AFC3B0 /* BoolValueTransformer.h */; };
-		FEED0000000000000000B003 /* NSColorValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000B001 /* NSColorValueTransformer.h */; };
 		6921294316F91C6600AFC3B0 /* BoolValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 6921294116F91C6600AFC3B0 /* BoolValueTransformer.m */; };
-		FEED0000000000000000B004 /* NSColorValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000B002 /* NSColorValueTransformer.m */; };
 		6921294716F91C7E00AFC3B0 /* IsEmptyCollectionValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = 6921294516F91C7E00AFC3B0 /* IsEmptyCollectionValueTransformer.h */; };
 		6921294816F91C7E00AFC3B0 /* IsEmptyCollectionValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = 6921294616F91C7E00AFC3B0 /* IsEmptyCollectionValueTransformer.m */; };
 		69220709249B9FDA009F8CD1 /* SEBScrollLockIcon@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 69220706249B9FD9009F8CD1 /* SEBScrollLockIcon@3x.png */; };
@@ -219,6 +211,13 @@
 		6947D89A1BB073EA00899A8A /* ZoomPageOut.png in Resources */ = {isa = PBXBuildFile; fileRef = 6947D8961BB073EA00899A8A /* ZoomPageOut.png */; };
 		6947D89B1BB073EA00899A8A /* ZoomPageOut@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6947D8971BB073EA00899A8A /* ZoomPageOut@2x.png */; };
 		694803931C236E7800593711 /* SEBiOSConfigFileController.m in Sources */ = {isa = PBXBuildFile; fileRef = 694803921C236E7800593711 /* SEBiOSConfigFileController.m */; };
+		69482BBD302F53F200E4CFEB /* SEBAllowedSEBVersions.h in Headers */ = {isa = PBXBuildFile; fileRef = 69482BBC302F53F200E4CFEB /* SEBAllowedSEBVersions.h */; };
+		69482BBE302F53F200E4CFEB /* SEBAllowedSEBVersions.h in Headers */ = {isa = PBXBuildFile; fileRef = 69482BBC302F53F200E4CFEB /* SEBAllowedSEBVersions.h */; };
+		69482BC0302F542100E4CFEB /* SEBAllowedSEBVersions.m in Sources */ = {isa = PBXBuildFile; fileRef = 69482BBF302F542100E4CFEB /* SEBAllowedSEBVersions.m */; };
+		69482BC1302F542100E4CFEB /* SEBAllowedSEBVersions.m in Sources */ = {isa = PBXBuildFile; fileRef = 69482BBF302F542100E4CFEB /* SEBAllowedSEBVersions.m */; };
+		69482BC3302F55AE00E4CFEB /* SEBAllowedSEBVersionsTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69482BC2302F55AE00E4CFEB /* SEBAllowedSEBVersionsTestSupport.swift */; };
+		69482BC4302F55AE00E4CFEB /* SEBAllowedSEBVersionsTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69482BC2302F55AE00E4CFEB /* SEBAllowedSEBVersionsTestSupport.swift */; };
+		69482BC6302F57D100E4CFEB /* SEBAllowedSEBVersionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69482BC5302F57D100E4CFEB /* SEBAllowedSEBVersionsTests.swift */; };
 		6949A47B1D0B8D9E0040ABF1 /* SEBNavigationController.h in Headers */ = {isa = PBXBuildFile; fileRef = 6949A4791D0B8D9E0040ABF1 /* SEBNavigationController.h */; };
 		6949A47C1D0B8D9E0040ABF1 /* SEBNavigationController.m in Sources */ = {isa = PBXBuildFile; fileRef = 6949A47A1D0B8D9E0040ABF1 /* SEBNavigationController.m */; };
 		694A7A5F24890B8E00B45C88 /* SEBProctoringViewIcon_error@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 694A7A5624890B8D00B45C88 /* SEBProctoringViewIcon_error@2x.png */; };
@@ -422,8 +421,6 @@
 		698A176D300FE275006646A9 /* SEBCryptorConfigKeyTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 698A176B300FE275006646A9 /* SEBCryptorConfigKeyTestSupport.swift */; };
 		698A176F300FE2B8006646A9 /* SEBCryptor+Testing.h in Headers */ = {isa = PBXBuildFile; fileRef = 698A176E300FE2B8006646A9 /* SEBCryptor+Testing.h */; };
 		698A1770300FE2B8006646A9 /* SEBCryptor+Testing.h in Headers */ = {isa = PBXBuildFile; fileRef = 698A176E300FE2B8006646A9 /* SEBCryptor+Testing.h */; };
-		FEED0000000000000000A006 /* SEBBrowserController+Testing.h in Headers */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000A005 /* SEBBrowserController+Testing.h */; };
-		FEED0000000000000000A007 /* SEBBrowserController+Testing.h in Headers */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000A005 /* SEBBrowserController+Testing.h */; };
 		698A20A42D85B36300C58815 /* KeyboardToolbarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 698A20A32D85B36300C58815 /* KeyboardToolbarButton.swift */; };
 		698A20A62D85B37B00C58815 /* KeyboardToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 698A20A52D85B37B00C58815 /* KeyboardToolbar.swift */; };
 		698AB4172638630A00E84161 /* SEBiOSBrowserController.h in Headers */ = {isa = PBXBuildFile; fileRef = 698AB4152638630A00E84161 /* SEBiOSBrowserController.h */; };
@@ -911,6 +908,16 @@
 		69FC8F5028743C5C00ECD0A3 /* SEBNetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69FC8F4F28743C5C00ECD0A3 /* SEBNetworkManager.swift */; };
 		69FF14AC1A1BB10300912933 /* SEBFilterArrayController.h in Headers */ = {isa = PBXBuildFile; fileRef = 69FF14AA1A1BB10300912933 /* SEBFilterArrayController.h */; };
 		69FF14AD1A1BB10300912933 /* SEBFilterArrayController.m in Sources */ = {isa = PBXBuildFile; fileRef = 69FF14AB1A1BB10300912933 /* SEBFilterArrayController.m */; };
+		FEED0000000000000000A002 /* SEBBrowserControllerTrustTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000A001 /* SEBBrowserControllerTrustTestSupport.swift */; };
+		FEED0000000000000000A004 /* SEBBrowserControllerTrustTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000A003 /* SEBBrowserControllerTrustTests.swift */; };
+		FEED0000000000000000A006 /* SEBBrowserController+Testing.h in Headers */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000A005 /* SEBBrowserController+Testing.h */; };
+		FEED0000000000000000A007 /* SEBBrowserController+Testing.h in Headers */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000A005 /* SEBBrowserController+Testing.h */; };
+		FEED0000000000000000B003 /* NSColorValueTransformer.h in Headers */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000B001 /* NSColorValueTransformer.h */; };
+		FEED0000000000000000B004 /* NSColorValueTransformer.m in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000B002 /* NSColorValueTransformer.m */; };
+		FEED0000000000000000C002 /* SEBServerCertificateFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000C001 /* SEBServerCertificateFetcher.swift */; };
+		FEED0000000000000000C003 /* SEBServerCertificateFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000C001 /* SEBServerCertificateFetcher.swift */; };
+		FEED0000000000000000C012 /* SEBServerCertificateFetchUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000C011 /* SEBServerCertificateFetchUI.swift */; };
+		FEED0000000000000000C013 /* SEBServerCertificateFetchUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000C011 /* SEBServerCertificateFetchUI.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1021,20 +1028,14 @@
 		691774481A2776FB0039CC39 /* SEBURLFilterRegexExpression.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SEBURLFilterRegexExpression.h; sourceTree = "<group>"; };
 		691774491A2776FB0039CC39 /* SEBURLFilterRegexExpression.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SEBURLFilterRegexExpression.m; sourceTree = "<group>"; };
 		6918BCB4301ACEEC00E602A2 /* SEBLockdownModePolicyMigrationTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SEBLockdownModePolicyMigrationTestSupport.swift; sourceTree = "<group>"; };
-		FEED0000000000000000A001 /* SEBBrowserControllerTrustTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SEBBrowserControllerTrustTestSupport.swift; path = Classes/BrowserComponents/SEBBrowserControllerTrustTestSupport.swift; sourceTree = "<group>"; };
-		FEED0000000000000000A003 /* SEBBrowserControllerTrustTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SEBBrowserControllerTrustTests.swift; sourceTree = "<group>"; };
 		6918BCB6301ACF9E00E602A2 /* SEBLockdownModePolicyMigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SEBLockdownModePolicyMigrationTests.swift; sourceTree = "<group>"; };
 		6918BCB82D419BA5002A9C57 /* SEBGCMCryptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SEBGCMCryptor.swift; sourceTree = "<group>"; };
-		FEED0000000000000000C011 /* SEBServerCertificateFetchUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SEBServerCertificateFetchUI.swift; sourceTree = "<group>"; };
-		FEED0000000000000000C001 /* SEBServerCertificateFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SEBServerCertificateFetcher.swift; sourceTree = "<group>"; };
 		691981412C723B7500E79DA4 /* FIFOBuffer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FIFOBuffer.swift; sourceTree = "<group>"; };
 		691981442C72520A00E79DA4 /* ScreenShotCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenShotCache.swift; sourceTree = "<group>"; };
 		691CD9AA1468947E00B43CDC /* SEBEncryptedUserDefaultsController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SEBEncryptedUserDefaultsController.h; path = Classes/Preferences/SEBEncryptedUserDefaultsController.h; sourceTree = "<group>"; };
 		691CD9AB1468947E00B43CDC /* SEBEncryptedUserDefaultsController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SEBEncryptedUserDefaultsController.m; path = Classes/Preferences/SEBEncryptedUserDefaultsController.m; sourceTree = "<group>"; };
 		6921294016F91C6600AFC3B0 /* BoolValueTransformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BoolValueTransformer.h; sourceTree = "<group>"; };
-		FEED0000000000000000B001 /* NSColorValueTransformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSColorValueTransformer.h; sourceTree = "<group>"; };
 		6921294116F91C6600AFC3B0 /* BoolValueTransformer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BoolValueTransformer.m; sourceTree = "<group>"; };
-		FEED0000000000000000B002 /* NSColorValueTransformer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSColorValueTransformer.m; sourceTree = "<group>"; };
 		6921294516F91C7E00AFC3B0 /* IsEmptyCollectionValueTransformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IsEmptyCollectionValueTransformer.h; sourceTree = "<group>"; };
 		6921294616F91C7E00AFC3B0 /* IsEmptyCollectionValueTransformer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IsEmptyCollectionValueTransformer.m; sourceTree = "<group>"; };
 		69220706249B9FD9009F8CD1 /* SEBScrollLockIcon@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "SEBScrollLockIcon@3x.png"; path = "Resources/Icons/Dock/SEBScrollLockIcon@3x.png"; sourceTree = "<group>"; };
@@ -1160,6 +1161,10 @@
 		694803941C2373AD00593711 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.2.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		694803961C2373CC00593711 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.2.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		694803981C2373E900593711 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.2.sdk/System/Library/Frameworks/CoreGraphics.framework; sourceTree = DEVELOPER_DIR; };
+		69482BBC302F53F200E4CFEB /* SEBAllowedSEBVersions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SEBAllowedSEBVersions.h; sourceTree = "<group>"; };
+		69482BBF302F542100E4CFEB /* SEBAllowedSEBVersions.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SEBAllowedSEBVersions.m; sourceTree = "<group>"; };
+		69482BC2302F55AE00E4CFEB /* SEBAllowedSEBVersionsTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SEBAllowedSEBVersionsTestSupport.swift; sourceTree = "<group>"; };
+		69482BC5302F57D100E4CFEB /* SEBAllowedSEBVersionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SEBAllowedSEBVersionsTests.swift; sourceTree = "<group>"; };
 		6949A4791D0B8D9E0040ABF1 /* SEBNavigationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SEBNavigationController.h; path = Classes/AdditionalViews/SEBNavigationController.h; sourceTree = "<group>"; };
 		6949A47A1D0B8D9E0040ABF1 /* SEBNavigationController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SEBNavigationController.m; path = Classes/AdditionalViews/SEBNavigationController.m; sourceTree = "<group>"; };
 		694A7A5624890B8D00B45C88 /* SEBProctoringViewIcon_error@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "SEBProctoringViewIcon_error@2x.png"; path = "Resources/Icons/Dock/SEBProctoringViewIcon_error@2x.png"; sourceTree = "<group>"; };
@@ -1356,7 +1361,6 @@
 		698A1769300FD80C006646A9 /* SEBConfigKeyDoubleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SEBConfigKeyDoubleTests.swift; sourceTree = "<group>"; };
 		698A176B300FE275006646A9 /* SEBCryptorConfigKeyTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SEBCryptorConfigKeyTestSupport.swift; sourceTree = "<group>"; };
 		698A176E300FE2B8006646A9 /* SEBCryptor+Testing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SEBCryptor+Testing.h"; sourceTree = "<group>"; };
-		FEED0000000000000000A005 /* SEBBrowserController+Testing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SEBBrowserController+Testing.h"; path = "Classes/BrowserComponents/SEBBrowserController+Testing.h"; sourceTree = "<group>"; };
 		698A20A32D85B36300C58815 /* KeyboardToolbarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardToolbarButton.swift; sourceTree = "<group>"; };
 		698A20A52D85B37B00C58815 /* KeyboardToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardToolbar.swift; sourceTree = "<group>"; };
 		698AB4152638630A00E84161 /* SEBiOSBrowserController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SEBiOSBrowserController.h; path = Classes/BrowserComponents/SEBiOSBrowserController.h; sourceTree = "<group>"; };
@@ -1776,6 +1780,13 @@
 		D32A1D6CDEC2CF1C15F44B7B /* Pods-SEB.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SEB.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SEB/Pods-SEB.debug.xcconfig"; sourceTree = "<group>"; };
 		E930E3E85BBD8B26A6A5BBCE /* Pods_SEB.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SEB.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FD0AEC1826F0E1C74E39CAA1 /* Pods_Safe_Exam_Browser_ETH.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Safe_Exam_Browser_ETH.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FEED0000000000000000A001 /* SEBBrowserControllerTrustTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SEBBrowserControllerTrustTestSupport.swift; path = Classes/BrowserComponents/SEBBrowserControllerTrustTestSupport.swift; sourceTree = "<group>"; };
+		FEED0000000000000000A003 /* SEBBrowserControllerTrustTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SEBBrowserControllerTrustTests.swift; sourceTree = "<group>"; };
+		FEED0000000000000000A005 /* SEBBrowserController+Testing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SEBBrowserController+Testing.h"; path = "Classes/BrowserComponents/SEBBrowserController+Testing.h"; sourceTree = "<group>"; };
+		FEED0000000000000000B001 /* NSColorValueTransformer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSColorValueTransformer.h; sourceTree = "<group>"; };
+		FEED0000000000000000B002 /* NSColorValueTransformer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSColorValueTransformer.m; sourceTree = "<group>"; };
+		FEED0000000000000000C001 /* SEBServerCertificateFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SEBServerCertificateFetcher.swift; sourceTree = "<group>"; };
+		FEED0000000000000000C011 /* SEBServerCertificateFetchUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SEBServerCertificateFetchUI.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2294,6 +2305,7 @@
 				6940B9871BA0F2FB008C8CFC /* Info.plist */,
 				69BAAE152CA03FD7002B14FB /* SEBIntegrationTests.swift */,
 				698A1769300FD80C006646A9 /* SEBConfigKeyDoubleTests.swift */,
+				69482BC5302F57D100E4CFEB /* SEBAllowedSEBVersionsTests.swift */,
 			);
 			path = SEBTests;
 			sourceTree = "<group>";
@@ -2569,6 +2581,9 @@
 				695EE19126D2F2F8004D8FF7 /* SEBPresetSettings.m */,
 				693425772D954D3F00BCBF0B /* AdditionalApplicationsController.swift */,
 				6918BCB4301ACEEC00E602A2 /* SEBLockdownModePolicyMigrationTestSupport.swift */,
+				69482BBC302F53F200E4CFEB /* SEBAllowedSEBVersions.h */,
+				69482BBF302F542100E4CFEB /* SEBAllowedSEBVersions.m */,
+				69482BC2302F55AE00E4CFEB /* SEBAllowedSEBVersionsTestSupport.swift */,
 			);
 			name = "Config Files";
 			path = Classes/ConfigFiles;
@@ -3254,6 +3269,7 @@
 				6974C0492475E354009F0529 /* ProctoringVideoCapturer.h in Headers */,
 				693FB270232064110062E36E /* SEBServerViewController.h in Headers */,
 				6932ABC521DE29BE00DEF77D /* SEBConstants.h in Headers */,
+				69482BBD302F53F200E4CFEB /* SEBAllowedSEBVersions.h in Headers */,
 				697852C72177AC7300E93AD8 /* SEBEncapsulatedSettings.h in Headers */,
 				69C3FC662A9B5EC600F4AFFD /* MyGlobals.h in Headers */,
 				69E977D625F040F400634D74 /* SEBAbstractClassicWebView.h in Headers */,
@@ -3436,6 +3452,7 @@
 				6917744A1A2776FB0039CC39 /* SEBURLFilterRegexExpression.h in Headers */,
 				69CE9C5D17326AB90011609B /* SEBConfigFileManager.h in Headers */,
 				69CE9C6317378B9A0011609B /* SEBTextField.h in Headers */,
+				69482BBE302F53F200E4CFEB /* SEBAllowedSEBVersions.h in Headers */,
 				698DFD3E267EA31C00B8F1D6 /* HUDPanel.h in Headers */,
 				69F522A421467188009F3999 /* CacheStoragePolicy.h in Headers */,
 				69EC2A3F1BD6C4FF00790AF7 /* WebPluginDatabase.h in Headers */,
@@ -4233,6 +4250,7 @@
 				698AB4272638C2B800E84161 /* NSURL+SEBURL.m in Sources */,
 				69C6A3542C738A2600033B3E /* SEBFileManager.swift in Sources */,
 				691056022C0A223600C491DE /* AssessmentConfigurationManager.swift in Sources */,
+				69482BC1302F542100E4CFEB /* SEBAllowedSEBVersions.m in Sources */,
 				6943C6532A99258600EC18FF /* QRCodeReaderView.m in Sources */,
 				694316651BFF943C00F784EE /* MyGlobals.m in Sources */,
 				69E0F3481C454F370038CCCD /* SEB.xcdatamodeld in Sources */,
@@ -4303,6 +4321,7 @@
 				6958C4592BD2BF3200B9F5D2 /* SEBOSXSessionState.swift in Sources */,
 				69A0723A268A38AD00A0464B /* MscX509CommonLocalException.m in Sources */,
 				6958C45C2BD8017000B9F5D2 /* ScreenProctoringServiceResources.swift in Sources */,
+				69482BC4302F55AE00E4CFEB /* SEBAllowedSEBVersionsTestSupport.swift in Sources */,
 				69D6A807280987F900E1375B /* SEBBatteryController.m in Sources */,
 				698F3F091D182A5E003DABBC /* SEBSliderItem.m in Sources */,
 				6943C6572A99258600EC18FF /* QRCodeReader.m in Sources */,
@@ -4368,6 +4387,7 @@
 			files = (
 				69B7A4DA2C694CAE00094ED3 /* SafeExamBrowserTests.swift in Sources */,
 				6918BCB7301ACF9E00E602A2 /* SEBLockdownModePolicyMigrationTests.swift in Sources */,
+				69482BC6302F57D100E4CFEB /* SEBAllowedSEBVersionsTests.swift in Sources */,
 				FEED0000000000000000A004 /* SEBBrowserControllerTrustTests.swift in Sources */,
 				69BAD4E33013AF19003887E8 /* SEBKeychainPasswordHashTests.swift in Sources */,
 				69B7A4E02C694D7400094ED3 /* SEBScreenCaptureControllerTests.swift in Sources */,
@@ -4479,12 +4499,14 @@
 				6915F2EA19C8F77600DAEA37 /* SEBDockWindow.m in Sources */,
 				69B5E2A625756BEF009030C2 /* SEBAbstractWebView.m in Sources */,
 				69A332372FBB54B200FF96FF /* WKWebView+SEBEvaluateJavaScript.m in Sources */,
+				69482BC3302F55AE00E4CFEB /* SEBAllowedSEBVersionsTestSupport.swift in Sources */,
 				691056012C0A223600C491DE /* AssessmentConfigurationManager.swift in Sources */,
 				6930D22D1C2086010087F79E /* SEBOSXKeychainManager.m in Sources */,
 				69F522BD21467188009F3999 /* CanonicalRequest.m in Sources */,
 				6958C45B2BD8017000B9F5D2 /* ScreenProctoringServiceResources.swift in Sources */,
 				6940A7621853B2AD00D9D00D /* NSData+NSDataZIPExtension.m in Sources */,
 				698DFD44267EA3D900B8F1D6 /* NSScreen+SEBScreen.m in Sources */,
+				69482BC0302F542100E4CFEB /* SEBAllowedSEBVersions.m in Sources */,
 				693F135315767CD600B1724E /* NSUserDefaults+SEBEncryptedUserDefaults.m in Sources */,
 				69C6522E2BC594E1003CAA74 /* SEBScreenProctoringController.swift in Sources */,
 				693EB53E15EF60A800DBA0B1 /* NSUserDefaultsController+SEBEncryptedUserDefaultsController.m in Sources */,


### PR DESCRIPTION
## Summary

Adds a new cross-platform configuration key **`sebAllowedVersions`** (an array of restriction strings) that lets an institutional admin require specific SEB client version(s) to use a configuration. When the running SEB build does not satisfy the restrictions, SEB shows a blocking alert offering to open the download page and then quits.

Restriction grammar: `OS.Major.Minor.[Patch].[Build].[AE].[min]` (bracketed parts optional). `OS` ∈ `Win`/`Mac`/`iOS`; `min` = "this version or newer"; `AE` = Alliance Edition. On macOS the build is currently never Alliance Edition, so `Mac…AE` restrictions never match.

## Changes

- **`SEBAllowedSEBVersions`** — pure, unit-tested helper that parses/evaluates the restriction grammar and builds the requirement text. Only `Mac` restrictions can allow this build; a valid restriction for another platform blocks; a list of only empty/malformed entries is treated as no restriction.
- **`SEBSettings`** — registers the `sebAllowedVersions` default (array of strings; auto-included in the Config Key).
- **`SEBController`** — `checkAllowedSEBVersions` runs during session (re)start; on a disallowed version it aborts init and presents a critical alert (Download SEB → localized download page then quit / Quit SEB), deferred to the next run loop with the app activated so it reliably comes to front.
- **Security preferences** — editable "Allowed SEB Versions" table (add/remove), persisting only trimmed, non-empty entries.
- **`PreferencesController.windowWillClose:` fix** — post the restart notification whenever a restart was requested and we're not in the refresh dance, even if the window is already hidden. Previously this could be dropped during the reconfigure open/close dance, so the session never restarted (no alert, no browser). Also fixes the same latent issue for `checkMinMacOSVersion` / AAC-unsupported checks.
- **Unit tests** — 19 cases, all passing.

## Testing
- `SEBAllowedSEBVersionsTests` — 19/19 pass.
- Manual: `Mac.99.0.min` / `Win.3.9.min` show the alert on first close; Download opens the localized page then quits; Quit quits; allowed restriction starts normally; Security-table add/edit/remove round-trips as `[String]`.

## Notes
- The `CFBundleVersion` build-number bump was intentionally left out of this branch.
- Cross-platform coordination: SEB for Windows must use the same key name and identical grammar/casing, or the Config Key hash diverges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)